### PR TITLE
添加一个校验业务逻辑错误返回码的方法

### DIFF
--- a/YTKNetwork/YTKBaseRequest.h
+++ b/YTKNetwork/YTKBaseRequest.h
@@ -164,6 +164,9 @@ typedef void (^AFDownloadProgressBlock)(AFDownloadRequestOperation *operation, N
 /// 用于检查Status Code是否正常的方法
 - (BOOL)statusCodeValidator;
 
+/// 用于检查Status Code为200时, 业务逻辑是否发生错误
+- (BOOL)returnCodeValidator;
+
 /// 当POST的内容带有文件等富文本时使用
 - (AFConstructingBlock)constructingBodyBlock;
 

--- a/YTKNetwork/YTKBaseRequest.m
+++ b/YTKNetwork/YTKBaseRequest.m
@@ -95,6 +95,11 @@
     }
 }
 
+- (BOOL)returnCodeValidator
+{
+    return YES;
+}
+
 - (AFConstructingBlock)constructingBodyBlock {
     return nil;
 }

--- a/YTKNetwork/YTKNetworkAgent.m
+++ b/YTKNetwork/YTKNetworkAgent.m
@@ -217,6 +217,10 @@
     if (!result) {
         return result;
     }
+    result = [request returnCodeValidator];
+    if (!result) {
+        return result;
+    }
     id validator = [request jsonValidator];
     if (validator != nil) {
         id json = [request responseJSONObject];


### PR DESCRIPTION
添加一个在请求的status code为200时，但是业务逻辑错误时的处理方法。
比如说注册业务，重复注册时，请求服务器得到的response的status code为200。但是此时的业务逻辑是错误。可能需要解析服务器返回json中的errorCode或者status字段。
如果在request的start call back中处理业务逻辑的错误也是可以的。但是如果是使用chainRequest时，则不会因为这种业务逻辑错误而中止后续的请求。所以在校验status code的同时加入业务返回码校验。

example：

```
MyRequest: YTKRequest

- (BOO)returnCodeValidator
{
    BOOL result = [super returnCodeValidator];
    if (!result) {
        if (self.responseJSONObject) {
            NSInteger returnCode = [[self.responseJSONObject objectForKey:@"Error"] integerValue];
            returnCode = returnCode / 100000;
            if (returnCode == 2) {
                // 认证失败
                result = NO;
            }
        }
    }
    return result;
}

```
