### PR TITLE
解决提出的问题-new

### DIFF
--- a/YTKNetwork/YTKBaseRequest.h
+++ b/YTKNetwork/YTKBaseRequest.h
@@ -173,4 +173,11 @@ typedef void (^AFDownloadProgressBlock)(AFDownloadRequestOperation *operation, N
 /// 当需要断点续传时，获得下载进度的回调
 - (AFDownloadProgressBlock)resumableDownloadProgressBlock;
 
+/// 忽略的参数列表
+- (NSArray *)ignoreArgumentNames;
+
+/// 重新修改请求参数名称
+- (NSDictionary *)configArguments;
+
+
 @end

--- a/YTKNetwork/YTKBaseRequest.m
+++ b/YTKNetwork/YTKBaseRequest.m
@@ -55,26 +55,49 @@
     unsigned int propCount;
     objc_property_t* properties = class_copyPropertyList([self class], &propCount);
     
-    NSMutableDictionary *parmas = [[NSMutableDictionary alloc] initWithCapacity:propCount];
+    NSMutableDictionary *params = [[NSMutableDictionary alloc] initWithCapacity:propCount];
+    
+    NSArray *ignoreParams = [self ignoreArgumentNames];
+    
+    NSDictionary *mappingPatamsDic = [self configArguments];
     
     for (int i=0; i<propCount; i++) {
         
         objc_property_t prop = properties[i];
         const char *propName = property_getName(prop);
         
+        NSString *originalKey = [NSString stringWithCString:propName encoding:NSUTF8StringEncoding];
+        
+        //忽略参数
+        if (ignoreParams) {
+            if ([ignoreParams containsObject:originalKey]) {
+                continue;
+            }
+        }
+        
+        // 填充请求字典
         if(propName) {
             
-            NSString *key = [NSString stringWithCString:propName encoding:NSUTF8StringEncoding];
+            NSString *changeKey;
+            
+            // 根据映射字典，修改请求参数名称
+            if (mappingPatamsDic) {
+                
+                changeKey = [mappingPatamsDic valueForKey:originalKey];
+                
+            }else{
+                changeKey = originalKey;
+            }
             
             id value = objc_msgSend(self, sel_registerName(propName));
             
-            [parmas setObject:value forKey:key];
+            [params setObject:value forKey:changeKey];
             
         }
         
     }
     
-    return parmas;
+    return params;
 }
 
 - (id)cacheFileNameFilterForRequestArgument:(id)argument {
@@ -189,6 +212,28 @@
         self.requestAccessories = [NSMutableArray array];
     }
     [self.requestAccessories addObject:accessory];
+}
+
+/**
+ *  忽略的参数列表
+ *
+ *  @return 忽略的参数列表
+ */
+- (NSArray *)ignoreArgumentNames;
+{
+    return nil;
+}
+
+/**
+ *  重新修改请求参数名称
+ * 
+ *  示例：{@“原来的参数名称”:@"服务器的请求参数名称"}
+ *
+ *  @return 参数名称映射字典
+ */
+- (NSDictionary *)configArguments
+{
+    return nil;
 }
 
 @end

--- a/YTKNetwork/YTKBaseRequest.m
+++ b/YTKNetwork/YTKBaseRequest.m
@@ -25,6 +25,7 @@
 #import "YTKNetworkAgent.h"
 #import "YTKNetworkPrivate.h"
 #import <objc/runtime.h>
+#import <objc/message.h>
 
 @implementation YTKBaseRequest
 

--- a/YTKNetwork/YTKBaseRequest.m
+++ b/YTKNetwork/YTKBaseRequest.m
@@ -24,6 +24,7 @@
 #import "YTKBaseRequest.h"
 #import "YTKNetworkAgent.h"
 #import "YTKNetworkPrivate.h"
+#import <objc/runtime.h>
 
 @implementation YTKBaseRequest
 
@@ -51,7 +52,29 @@
 }
 
 - (id)requestArgument {
-    return nil;
+    unsigned int propCount;
+    objc_property_t* properties = class_copyPropertyList([self class], &propCount);
+    
+    NSMutableDictionary *parmas = [[NSMutableDictionary alloc] initWithCapacity:propCount];
+    
+    for (int i=0; i<propCount; i++) {
+        
+        objc_property_t prop = properties[i];
+        const char *propName = property_getName(prop);
+        
+        if(propName) {
+            
+            NSString *key = [NSString stringWithCString:propName encoding:NSUTF8StringEncoding];
+            
+            id value = objc_msgSend(self, sel_registerName(propName));
+            
+            [parmas setObject:value forKey:key];
+            
+        }
+        
+    }
+    
+    return parmas;
 }
 
 - (id)cacheFileNameFilterForRequestArgument:(id)argument {


### PR DESCRIPTION
1. 解决 部分属性不想作为参数传递 的问题。
2. 解决 服务器接受的参数名可能跟porperty的命名不一致 的问题

示例：
在Api类里面实现方法
- (NSArray *)ignoreArgumentNames
{
    return @[@"telNum"];
}

- (NSDictionary *)configArguments
{
    return @{@"tel_local" : @"tel"};
}

至于你们提到的参数复杂结构问题，目前还没遇到过，能给个示例吗？目前开发遇到网络请求，参数都是一级结构，还没有遇到类似返回JSON那种多层级结构的请求参数。