### PR TITLE
为manager添加了多内容支持

### DIFF
--- a/YTKNetwork/YTKNetworkAgent.m
+++ b/YTKNetwork/YTKNetworkAgent.m
@@ -46,6 +46,7 @@
     if (self) {
         _config = [YTKNetworkConfig sharedInstance];
         _manager = [AFHTTPRequestOperationManager manager];
+        _manager.responseSerializer.acceptableContentTypes = [NSSet setWithObjects:@"application/json", @"text/plain", @"text/javascript", @"text/json", @"text/html", nil];
         _requestsRecord = [NSMutableDictionary dictionary];
         _manager.operationQueue.maxConcurrentOperationCount = 4;
     }


### PR DESCRIPTION
        _manager.responseSerializer.acceptableContentTypes = [NSSet setWithObjects:@"application/json", @"text/plain", @"text/javascript", @"text/json", @"text/html", nil];
项目中对于服务器的返回值有多种内容形式，需要加入这句代码才能使用