### PR TITLE
FIX: support `HTTPMethodsEncodingParametersInURI`

### DIFF
--- a/YTKNetwork/YTKBaseRequest.h
+++ b/YTKNetwork/YTKBaseRequest.h
@@ -316,6 +316,9 @@ typedef void(^YTKRequestCompletionBlock)(__kindof YTKBaseRequest *request);
 ///  Additional HTTP request header field.
 - (nullable NSDictionary<NSString *, NSString *> *)requestHeaderFieldValueDictionary;
 
+/// HTTP methods for which serialized requests will encode parameters as a query string. `GET`, `HEAD`, and `DELETE` by default.
+- (nullable NSSet<NSString *> *)HTTPMethodsEncodingParametersInURI;
+
 ///  Use this to build custom request. If this method return non-nil value, `requestUrl`, `requestTimeoutInterval`,
 ///  `requestArgument`, `allowsCellularAccess`, `requestMethod` and `requestSerializerType` will all be ignored.
 - (nullable NSURLRequest *)buildCustomUrlRequest;

--- a/YTKNetwork/YTKBaseRequest.m
+++ b/YTKNetwork/YTKBaseRequest.m
@@ -182,13 +182,7 @@ NSString *const YTKRequestValidationErrorDomain = @"com.yuantiku.request.validat
 }
 
 - (NSSet *)HTTPMethodsEncodingParametersInURI {
-    static NSSet *set = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        set = [NSSet setWithObjects:@"GET", @"HEAD", @"DELETE", nil];
-    });
-
-    return set;
+    return [NSSet setWithObjects:@"GET", @"HEAD", @"DELETE", nil];
 }
 
 - (NSURLRequest *)buildCustomUrlRequest {

--- a/YTKNetwork/YTKBaseRequest.m
+++ b/YTKNetwork/YTKBaseRequest.m
@@ -181,6 +181,16 @@ NSString *const YTKRequestValidationErrorDomain = @"com.yuantiku.request.validat
     return nil;
 }
 
+- (NSSet *)HTTPMethodsEncodingParametersInURI {
+    static NSSet *set = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        set = [NSSet setWithObjects:@"GET", @"HEAD", @"DELETE", nil];
+    });
+
+    return set;
+}
+
 - (NSURLRequest *)buildCustomUrlRequest {
     return nil;
 }

--- a/YTKNetwork/YTKNetworkAgent.m
+++ b/YTKNetwork/YTKNetworkAgent.m
@@ -145,6 +145,8 @@
 
     requestSerializer.timeoutInterval = [request requestTimeoutInterval];
     requestSerializer.allowsCellularAccess = [request allowsCellularAccess];
+    requestSerializer.HTTPMethodsEncodingParametersInURI = [request HTTPMethodsEncodingParametersInURI];
+
 
     // If api needs server username and password
     NSArray<NSString *> *authorizationHeaderFieldArray = [request requestAuthorizationHeaderFieldArray];


### PR DESCRIPTION
### 提出 Pull Request 前请先确认完成了下列几项步骤 New Pull Request Checklist

* [x] 我已经阅读过 [贡献指南](CONTRIBUTING.md) I have read and understood the [CONTRIBUTING guide](CONTRIBUTING.md)
* [x] 我已经阅读过 [程序文档]((http://cocoadocs.org/docsets/YTKNetwork)) I have read the [Documentation](http://cocoadocs.org/docsets/YTKNetwork)
* [x] 我已经在项目的 [Pull Request 列表](https://github.com/yuantiku/YTKNetwork/pulls) 中搜索过并且没有找到类似的 Pull Request I have searched for a similar pull request in the [project](https://github.com/yuantiku/YTKNetwork/pulls) and found none
* [x] 我已经添加了必要的测试以证明我的改动是正确的 I have added the required tests to prove the fix/feature I am adding
* [x] 我已经更新了有关文档（如必要）I have updated the documentation (if necesarry)

### Pull Request 说明 Pull Request Description

这个 Pull Request 解决了如下问题/加入了如下功能：···

支持自定义`HTTPMethodsEncodingParametersInURI`：
默认情况下，执行`DELETE`请求会将请求参数放在url中，但是某些情况下`DELETE`请求时需要将请求参数放置到body中

This pull request fixes / reffers to the following issues: ...

