### PR TITLE
增加：忽略检查APP版本，导致缓存在APP升级中失效

### DIFF
--- a/YTKNetwork/YTKRequest.h
+++ b/YTKNetwork/YTKRequest.h
@@ -52,6 +52,10 @@ NS_ENUM(NSInteger) {
 ///  even `ignoreCache` is YES.
 @property (nonatomic) BOOL ignoreCache;
 
+// Whether the app version consistent fields need to be checked when obtaining the cache.
+// The default is no.
+@property (nonatomic) BOOL ignoreAppSameVersionCheck;
+
 ///  Whether data is from local cache.
 - (BOOL)isDataFromCache;
 

--- a/YTKNetwork/YTKRequest.m
+++ b/YTKNetwork/YTKRequest.m
@@ -279,6 +279,10 @@ static dispatch_queue_t ytkrequest_cache_writing_queue() {
     NSString *appVersionString = self.cacheMetadata.appVersionString;
     NSString *currentAppVersionString = [YTKNetworkUtils appVersionString];
     if (appVersionString || currentAppVersionString) {
+        if (self.ignoreAppSameVersionCheck) {
+            return YES;
+        }
+
         if (appVersionString.length != currentAppVersionString.length || ![appVersionString isEqualToString:currentAppVersionString]) {
             if (error) {
                 *error = [NSError errorWithDomain:YTKRequestCacheErrorDomain code:YTKRequestCacheErrorAppVersionMismatch userInfo:@{ NSLocalizedDescriptionKey:@"App version mismatch"}];


### PR DESCRIPTION
现况：app升级之后，所有缓存失效。
增加：由使用方控制字段，忽略app相同版本检查。